### PR TITLE
Replace Kags POP  runescape forum with wiki link

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                         <a class="dropdown-item" href="https://pvme.github.io" target="_blank" rel="noreferrer noopener" title="Ultimate guides for PVM">PVM Encyclopedia</a>
                         <a class="dropdown-item" href="https://runepixels.com/" target="_blank" rel="noreferrer noopener" title="Experience Tracker for Players and Clans">Runepixels</a>
                         <!-- <a class="dropdown-item" href="https://www.runeclan.com" target="_blank" rel="noreferrer noopener">RuneClan</a> -->
-                        <a class="dropdown-item" href="https://secure.runescape.com/m=forum/sl=0/forums?75,76,639,66118461,20,344835686#20" target="_blank" rel="noreferrer noopener" title="Complete guide to Player-owned Ports">Kags POP Encyclopedia</a>
+                        <a class="dropdown-item" href="https://runescape.wiki/w/User:Kags" target="_blank" rel="noreferrer noopener" title="Complete guide to Player-owned Ports">Kags POP Encyclopedia</a>
                         <a class="dropdown-item" href="https://www.reddit.com/r/runescape/comments/7j6lbr/guide_on_efficient_use_of_personal_slayer/" target="_blank" rel="noreferrer noopener" title="Guide to Player owned dungeons">Kags POD Guide</a>
                         <!-- <a class="dropdown-item" href="https://www.pct.wtf" target="_blank" rel="noreferrer noopener">Price Check &amp; Trade</a> -->
                         <a class="dropdown-item" href="https://www.ely.gg" target="_blank" rel="noreferrer noopener" title="Tracks prices for rares and other high value items - caveat emptor">Ely Rares Price Checker</a>


### PR DESCRIPTION
Since the forum closed down it was moved to the RS wiki instead.

it might also be worth removing the Kags POD guide as the reddit post is now deleted.